### PR TITLE
Add output to trello option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN npm run build:elm && npm run build:ts && npm run build:copy
 
 VOLUME /input
 
-ENTRYPOINT ["build/teamsort.js", "sort"]
+ENTRYPOINT ["build/teamsort"]

--- a/cli/elm.json
+++ b/cli/elm.json
@@ -10,16 +10,20 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
+            "elm/url": "1.0.0",
             "elm-community/list-extra": "8.2.4",
+            "elm-community/maybe-extra": "5.2.0",
             "elm-community/result-extra": "2.4.0",
             "lukewestby/elm-string-interpolate": "1.0.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,9 +7,9 @@
     "teamsort": "build/teamsort.js"
   },
   "scripts": {
-    "build": "concurrently -c cyan,yellow \"npm:build:elm\" \"npm:build:ts\" \"npm:build:copy\"",
+    "build": "yarn build:elm; yarn build:ts; yarn build:copy",
     "build:elm": "elm make src/Main.elm --output build/Main.js --optimize",
-    "build:ts": "tsc src/teamsort.ts --outDir build; chmod +x build/teamsort.js",
+    "build:ts": "tsc src/teamsort.ts --outDir build; cp build/teamsort.js build/teamsort; chmod +x build/teamsort",
     "build:copy": "cp src/teamsorting.mzn build",
     "watch": "concurrently -c cyan,yellow \"npm:watch:elm\" \"npm:watch:ts\" ",
     "watch:elm": "nodemon -w src -e elm --exec \"elm make src/Main.elm --output build/Main.js\"",

--- a/cli/package.json
+++ b/cli/package.json
@@ -18,9 +18,11 @@
   },
   "dependencies": {
     "@types/node": "^13.13.1",
+    "dotenv": "^8.2.0",
     "elm": "^0.19.1-3",
     "minizinc": "^3.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "xhr2": "^0.2.0"
   },
   "devDependencies": {
     "concurrently": "^5.1.0",

--- a/cli/src/Main.elm
+++ b/cli/src/Main.elm
@@ -39,19 +39,18 @@ programConfig =
     Program.config
         |> Program.add
             (OptionsParser.build (\file -> SortOptions file Nothing)
-                |> OptionsParser.with (Option.requiredPositionalArg "fileName")
+                |> OptionsParser.with (Option.requiredPositionalArg "file-name")
                 |> OptionsParser.withDoc "run sorting algorithm based on input file"
                 |> OptionsParser.map Sort
             )
         |> Program.add
             (OptionsParser.build
-                (\file trello board key token ->
+                (\file board key token ->
                     Just (TrelloIntegration board key token)
                         |> SortOptions file
                 )
-                |> OptionsParser.with (Option.requiredPositionalArg "fileName")
-                |> OptionsParser.with (Option.flag "trello")
-                |> OptionsParser.with (Option.requiredPositionalArg "boardName")
+                |> OptionsParser.with (Option.requiredPositionalArg "file-name")
+                |> OptionsParser.with (Option.requiredPositionalArg "trello-board-name")
                 |> OptionsParser.with (Option.optionalKeywordArg "trello-key")
                 |> OptionsParser.with (Option.optionalKeywordArg "trello-token")
                 |> OptionsParser.withDoc "sort and send result to given trello board"
@@ -519,22 +518,6 @@ keyAndToken config =
     [ Url.Builder.string "key" config.key
     , Url.Builder.string "token" config.token
     ]
-
-
-
-{-
-   Utils
--}
-
-
-maybeOr : Maybe a -> Maybe a -> Maybe a
-maybeOr ma mb =
-    case ma of
-        Nothing ->
-            mb
-
-        Just _ ->
-            ma
 
 
 

--- a/cli/src/Main.elm
+++ b/cli/src/Main.elm
@@ -169,17 +169,14 @@ update cliOptions msg model =
             case model.outputIntegration of
                 Trello config _ ->
                     ( model
-                    , Cmd.batch <|
-                        print ("Adding players to list " ++ list.name)
-                            :: List.map
-                                (addPlayerToTrelloList config list)
-                                team.players
+                    , print ("Adding players to list " ++ list.name)
+                        :: List.map
+                            (addPlayerToTrelloList config list)
+                            team.players
+                        |> Cmd.batch
                     )
 
                 _ ->
-                    {- This should not happen, but best way I have found so
-                       far to safely acces trello config
-                    -}
                     ( model, Cmd.none )
 
         TrelloListCreated (Err error) ->
@@ -208,16 +205,13 @@ update cliOptions msg model =
                             ( model, print "Could not find the spesified board" )
 
                 _ ->
-                    {- This should not happen, but best way I have found so
-                       far to safely acces trello config
-                    -}
-                    ( model, print "Could not find the spesified board" )
+                    ( model, print "Oops! Weird stuff just happend!" )
 
         TrelloSearchReceived (Err error) ->
             ( model
             , Cmd.batch
-                [ print <| errorcheck error
-                , print "Board search error:"
+                [ print "Fetching boards failed:"
+                , print <| errorcheck error
                 ]
             )
 

--- a/cli/src/Main.elm
+++ b/cli/src/Main.elm
@@ -121,11 +121,11 @@ init flags cliOptions =
                         Just config ->
                             ( { initModel | outputIntegration = Trello config trello.boardName }
                             , Cmd.batch
-                                [ readFile options.fileName
-                                ]
+                                readFile
+                                options.fileName
                             )
 
-                        _ ->
+                        Nothing ->
                             ( initModel, printAndExitFailure "Can not find trello config. Exiting." )
 
                 Nothing ->

--- a/cli/src/Main.elm
+++ b/cli/src/Main.elm
@@ -120,9 +120,7 @@ init flags cliOptions =
                     case inlineOrEnvConfig of
                         Just config ->
                             ( { initModel | outputIntegration = Trello config trello.boardName }
-                            , Cmd.batch
-                                readFile
-                                options.fileName
+                            , readFile options.fileName
                             )
 
                         Nothing ->

--- a/cli/src/Main.elm
+++ b/cli/src/Main.elm
@@ -4,26 +4,45 @@ import Array
 import Cli.Option as Option
 import Cli.OptionsParser as OptionsParser
 import Cli.Program as Program
+import Http
 import Json.Decode as JD
+import Json.Encode as JE
 import List
 import List.Extra
+import Maybe.Extra as ME
 import Result.Extra
 import SolverResult exposing (SolverResult, solverResultDecoder)
 import String.Interpolate exposing (interpolate)
 import Tuple
+import Url.Builder
 
 
 type CliOptions
-    = Generate String
+    = Sort SortOptions
+
+
+type alias SortOptions =
+    { fileName : String
+    , trello : Bool
+    , boardName : Maybe String
+    , trelloKey : Maybe String
+    , trelloToken : Maybe String
+    }
 
 
 programConfig : Program.Config CliOptions
 programConfig =
     Program.config
         |> Program.add
-            (OptionsParser.buildSubCommand "sort" Generate
-                |> OptionsParser.with (Option.requiredPositionalArg "fileName")
-                |> OptionsParser.withDoc "run sorting algorithm based on input file"
+            (OptionsParser.map Sort
+                (OptionsParser.buildSubCommand "sort" SortOptions
+                    |> OptionsParser.with (Option.requiredPositionalArg "fileName")
+                    |> OptionsParser.with (Option.flag "trello")
+                    |> OptionsParser.with (Option.optionalKeywordArg "boardName")
+                    |> OptionsParser.with (Option.optionalKeywordArg "trello-key")
+                    |> OptionsParser.with (Option.optionalKeywordArg "trello-token")
+                    |> OptionsParser.withDoc "run sorting algorithm based on input file"
+                )
             )
 
 
@@ -31,25 +50,77 @@ type Msg
     = FileReceived String
     | SolverResultReceived SolverResult
     | ErrorFromSubs String
+    | TrelloListCreated (Result Http.Error ( Team, TrelloList ))
+    | TrelloCardCreated (Result Http.Error String)
+    | TrelloSearchReceived (Result Http.Error ( List Team, List Board ))
 
 
 type alias Model =
-    { players : List Player }
+    { players : List Player
+    , outputIntegration : OutputIntegration
+    , trelloConfig : Maybe TrelloConfig
+    }
+
+
+type OutputIntegration
+    = Trello TrelloConfig String
+    | Terminal
+    | Unsupported
+
+
+type alias TrelloConfig =
+    { key : String
+    , token : String
+    }
 
 
 type alias Flags =
-    Program.FlagsIncludingArgv {}
+    Program.FlagsIncludingArgv Extras
+
+
+type alias Extras =
+    { trelloKey : Maybe String
+    , trelloToken : Maybe String
+    }
 
 
 init : Flags -> CliOptions -> ( Model, Cmd Msg )
 init flags cliOptions =
     let
         initModel =
-            { players = [] }
+            { players = []
+            , outputIntegration = Terminal
+            , trelloConfig =
+                Maybe.map2
+                    TrelloConfig
+                    flags.trelloKey
+                    flags.trelloToken
+            }
     in
     case cliOptions of
-        Generate fileName ->
-            ( initModel, readFile fileName )
+        Sort options ->
+            if options.trello then
+                let
+                    inlineOrEnvConfig =
+                        Maybe.map2 TrelloConfig options.trelloKey options.trelloToken
+                            |> ME.orElse initModel.trelloConfig
+                in
+                case ( inlineOrEnvConfig, options.boardName ) of
+                    ( Just config, Just boardName ) ->
+                        ( { initModel | outputIntegration = Trello config boardName }
+                        , Cmd.batch
+                            [ readFile options.fileName
+                            ]
+                        )
+
+                    ( _, Nothing ) ->
+                        ( initModel, printAndExitFailure "Board name not found. Use option --boardName to pass it" )
+
+                    _ ->
+                        ( initModel, printAndExitFailure "Can not find trello config. Exiting." )
+
+            else
+                ( initModel, readFile options.fileName )
 
 
 update : CliOptions -> Msg -> Model -> ( Model, Cmd Msg )
@@ -62,14 +133,113 @@ update cliOptions msg model =
             let
                 teams =
                     resultToTeams result model.players
+
+                output =
+                    case model.outputIntegration of
+                        Terminal ->
+                            teamsToString teams
+                                |> printAndExitSuccess
+
+                        Trello config boardName ->
+                            Cmd.batch
+                                [ teamsToString teams
+                                    |> String.append
+                                        ("\nSending result to Trello board \""
+                                            ++ boardName
+                                            ++ "\".\n\n"
+                                        )
+                                    |> print
+                                , trelloSearch config teams
+                                ]
+
+                        Unsupported ->
+                            Cmd.batch
+                                [ print "Unsupported output integration. Using Terminal."
+                                , teamsToString teams
+                                    |> printAndExitSuccess
+                                ]
             in
             ( model
-            , teamsToString teams
-                |> printAndExitSuccess
+            , output
+            )
+
+        TrelloListCreated (Ok ( team, list )) ->
+            case model.outputIntegration of
+                Trello config _ ->
+                    ( model
+                    , Cmd.batch <|
+                        print ("Adding players to list " ++ list.name)
+                            :: List.map
+                                (addPlayerToTrelloList config list)
+                                team.players
+                    )
+
+                _ ->
+                    {- This should not happen, but best way I have found so
+                       far to safely acces trello config
+                    -}
+                    ( model, Cmd.none )
+
+        TrelloListCreated (Err error) ->
+            ( model, print <| errorcheck error )
+
+        TrelloCardCreated (Ok resultString) ->
+            ( model, Cmd.none )
+
+        TrelloCardCreated (Err error) ->
+            ( model, print <| errorcheck error )
+
+        TrelloSearchReceived (Ok ( teams, boards )) ->
+            case model.outputIntegration of
+                Trello config boardName ->
+                    let
+                        boardId =
+                            boards
+                                |> List.Extra.find (.name >> (==) boardName)
+                                |> Maybe.map .id
+                    in
+                    case boardId of
+                        Just id ->
+                            ( model, sendToTrello config id teams )
+
+                        Nothing ->
+                            ( model, print "Could not find the spesified board" )
+
+                _ ->
+                    {- This should not happen, but best way I have found so
+                       far to safely acces trello config
+                    -}
+                    ( model, print "Could not find the spesified board" )
+
+        TrelloSearchReceived (Err error) ->
+            ( model
+            , Cmd.batch
+                [ print <| errorcheck error
+                , print "Board search error:"
+                ]
             )
 
         ErrorFromSubs error ->
             ( model, printAndExitFailure error )
+
+
+errorcheck : Http.Error -> String
+errorcheck error =
+    case error of
+        Http.BadUrl url ->
+            "Bad url: " ++ url
+
+        Http.Timeout ->
+            "HTTP timeout"
+
+        Http.NetworkError ->
+            "Network error"
+
+        Http.BadStatus status ->
+            "Bad status: " ++ String.fromInt status
+
+        Http.BadBody body ->
+            "Bad body: " ++ body
 
 
 resultToTeams : SolverResult -> List Player -> List Team
@@ -225,12 +395,152 @@ playerParser index content =
 
 
 
---Result.fromMaybe
---    errorMsg
---    (Maybe.map (Player desc) rankInt)
+{-
+   Trello
+-}
 
 
-main : Program.StatefulProgram Model Msg CliOptions {}
+trelloSearch : TrelloConfig -> List Team -> Cmd Msg
+trelloSearch config teams =
+    let
+        url =
+            Url.Builder.absolute
+                [ "1/members/me/boards"
+                ]
+                (Url.Builder.string "fields" "name,id"
+                    :: keyAndToken config
+                )
+    in
+    Http.get
+        { url = "https://api.trello.com" ++ url
+        , expect =
+            Http.expectJson TrelloSearchReceived (JD.map (Tuple.pair teams) boardsDecoder)
+        }
+
+
+boardsDecoder : JD.Decoder (List Board)
+boardsDecoder =
+    JD.list boardDecoder
+
+
+type alias Board =
+    { id : String
+    , name : String
+    }
+
+
+boardDecoder : JD.Decoder Board
+boardDecoder =
+    JD.map2 Board
+        (JD.field "id" JD.string)
+        (JD.field "name" JD.string)
+
+
+addPlayerToTrelloList : TrelloConfig -> TrelloList -> Player -> Cmd Msg
+addPlayerToTrelloList trelloConfig list player =
+    let
+        url =
+            Url.Builder.absolute
+                [ "1/cards"
+                ]
+                (Url.Builder.string "name"
+                    (String.join " "
+                        [ player.name
+                        , player.rankName
+                        , String.fromInt player.rank
+                        ]
+                    )
+                    :: Url.Builder.string "idList" list.id
+                    :: keyAndToken trelloConfig
+                )
+    in
+    Http.post
+        { url = "https://api.trello.com" ++ url
+        , body = Http.emptyBody
+        , expect =
+            Http.expectString TrelloCardCreated
+        }
+
+
+sendToTrello : TrelloConfig -> String -> List Team -> Cmd Msg
+sendToTrello trelloConfig boardId teams =
+    print "Creating lists from teams"
+        :: List.map (teamToListCreateRequest trelloConfig boardId) teams
+        |> Cmd.batch
+
+
+teamToListCreateRequest : TrelloConfig -> String -> Team -> Cmd Msg
+teamToListCreateRequest trelloConfig boardId team =
+    let
+        url =
+            Url.Builder.absolute
+                [ "1/boards"
+                , boardId
+                , "lists"
+                ]
+                (Url.Builder.string "pos" "bottom"
+                    :: Url.Builder.string "name" ("Team " ++ team.name)
+                    :: keyAndToken trelloConfig
+                )
+    in
+    Http.post
+        { url = "https://api.trello.com" ++ url
+        , body = Http.emptyBody
+        , expect =
+            Http.expectJson TrelloListCreated
+                (JD.map (Tuple.pair team) trelloListDecoder)
+        }
+
+
+type alias TrelloList =
+    { id : String
+    , name : String
+    , closed : Bool
+    , pos : Int
+    , idBoard : String
+    }
+
+
+trelloListDecoder : JD.Decoder TrelloList
+trelloListDecoder =
+    JD.map5 TrelloList
+        (JD.field "id" JD.string)
+        (JD.field "name" JD.string)
+        (JD.field "closed" JD.bool)
+        (JD.field "pos" JD.int)
+        (JD.field "idBoard" JD.string)
+
+
+keyAndToken : TrelloConfig -> List Url.Builder.QueryParameter
+keyAndToken config =
+    [ Url.Builder.string "key" config.key
+    , Url.Builder.string "token" config.token
+    ]
+
+
+
+{-
+   Utils
+-}
+
+
+maybeOr : Maybe a -> Maybe a -> Maybe a
+maybeOr ma mb =
+    case ma of
+        Nothing ->
+            mb
+
+        Just _ ->
+            ma
+
+
+
+{-
+   Program
+-}
+
+
+main : Program.StatefulProgram Model Msg CliOptions Extras
 main =
     Program.stateful
         { printAndExitFailure = printAndExitFailure

--- a/cli/src/teamsort.ts
+++ b/cli/src/teamsort.ts
@@ -5,17 +5,29 @@ import * as readline from 'readline';
 import * as fs from 'fs';
 import minizinc from './minizinc';
 
+require('dotenv').config();
+
+const globalAny: any = global;
+globalAny.XMLHttpRequest = require('xhr2');
+
 const fsPromise = fs.promises;
 
 const program = Elm.Main.init({
-    flags: { argv: process.argv, versionMessage: '0.0.1' },
+    flags: {
+        argv: process.argv,
+        versionMessage: '0.0.1',
+        trelloKey: process.env.TRELLO_KEY || null,
+        trelloToken: process.env.TRELLO_TOKEN || null,
+    },
 });
 
-// Ports out of Elm
+/* 
+    Ports out of Elm
+*/
 
-// program.ports.print.subscribe((message) => {
-//     console.log(message);
-// });
+program.ports.print.subscribe((message) => {
+    console.log(message);
+});
 
 program.ports.printAndExitFailure.subscribe((message) => {
     console.log(message);
@@ -27,14 +39,19 @@ program.ports.printAndExitSuccess.subscribe((message) => {
     process.exit(0);
 });
 
-// Port into Elm
+/*
+    Port into Elm
+*/
+
 // program.ports.writeFile.subscribe(writeFile);
 
 program.ports.readFile.subscribe((content) => readFile(program, content));
 
 program.ports.runSolver.subscribe(runSolver);
 
-// Functions
+/*
+    Functions
+*/
 
 function writeFile([file, content]) {
     return fsPromise.writeFile(file, content).catch((err) => console.log(err));

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -566,6 +566,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -2323,6 +2328,11 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xhr2@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.2.0.tgz#eddeff782f3b7551061b8d75645085269396e521"
+  integrity sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA==
 
 xmlbuilder@^13.0.2:
   version "13.0.2"


### PR DESCRIPTION
Adding support for Trello as an output option for the resulting teams.

For now it requires an api key and token and a board name.
Token and key can be supplied through environment variables (and `.env` file) and CLI options.

The api for the CLI can be discussed. This is a proposed first version.